### PR TITLE
commands: fix tracksprocessor at old id3v2.Open() api call

### DIFF
--- a/tracksprocessor/tracks_processor.go
+++ b/tracksprocessor/tracks_processor.go
@@ -119,7 +119,7 @@ func runDownloadCmd(path, url string) error {
 }
 
 func tag(t track.Track, trackPath string, artwork *os.File) error {
-	tag, e := id3v2.Open(trackPath)
+	tag, e := id3v2.Open(trackPath, id3v2.Options{Parse: true})
 	if e != nil {
 		return e
 	}

--- a/tracksprocessor/tracks_processor.go
+++ b/tracksprocessor/tracks_processor.go
@@ -119,7 +119,7 @@ func runDownloadCmd(path, url string) error {
 }
 
 func tag(t track.Track, trackPath string, artwork *os.File) error {
-	tag, e := id3v2.Open(trackPath, id3v2.Options{Parse: true})
+	tag, e := id3v2.Open(trackPath, id3v2.Options{Parse: false})
 	if e != nil {
 		return e
 	}


### PR DESCRIPTION
commands: fix missing function parameter in tracksprocessor at id3v2 Open() call